### PR TITLE
Amend HALNavigator.create()

### DIFF
--- a/restnavigator/halnav.py
+++ b/restnavigator/halnav.py
@@ -493,7 +493,7 @@ class HALNavigator(HALNavigatorBase):
         self._request(GET, raise_exc=raise_exc)  # ingests response
         return self.state.copy()
 
-    def create(self, body, raise_exc=True, headers=None):
+    def create(self, body=None, raise_exc=True, headers=None):
         '''Performs an HTTP POST to the server, to create a
         subordinate resource. Returns a new HALNavigator representing
         that resource.


### PR DESCRIPTION
Provide default None for body when sending POST via HALNavigator.create()

I have a web service that accepts POST on some links to change resource state without requiring a message body.
